### PR TITLE
Fix: skip analytics payload when no claims are extracted

### DIFF
--- a/app/observability/analytics/collector.py
+++ b/app/observability/analytics/collector.py
@@ -339,16 +339,7 @@ class AnalyticsCollector:
             if entry.extraction_status == "success":
                 self.add_scraped_link(url=entry.url, success=True, text=entry.content)
 
-        # b) claims — populate from claim verdicts
-        claim_num = 1
-        for ds_result in fact_check_result.results:
-            for cv in ds_result.claim_verdicts:
-                self.analytics.Claims[str(claim_num)] = ClaimAnalytics(
-                    text=cv.claim_text, links=[]
-                )
-                claim_num += 1
-
-        # c) adjudication output — fills ResponseByDataSource + ResponseByClaim + CommentAboutCompleteContext
+        # b) adjudication output — fills ResponseByDataSource + ResponseByClaim + CommentAboutCompleteContext
         self.populate_from_adjudication(fact_check_result)
         self.populate_from_fact_check_result(fact_check_result)
 
@@ -430,10 +421,10 @@ class AnalyticsCollector:
         check if any claims were extracted during the pipeline.
 
         returns:
-            True if at least one claim exists in Claims dict or
-            at least one claim verdict exists in ResponseByDataSource, False otherwise
+            True if ResponseByClaim has entries or ResponseByDataSource
+            contains at least one claim verdict, False otherwise
         """
-        if len(self.analytics.Claims) > 0:
+        if len(self.analytics.ResponseByClaim) > 0:
             return True
         return any(
             len(ds.claim_verdicts) > 0

--- a/app/observability/analytics/tests/test_collector.py
+++ b/app/observability/analytics/tests/test_collector.py
@@ -265,35 +265,6 @@ def test_has_extracted_claims_true_after_populate():
     assert col.has_extracted_claims() is True
 
 
-def test_claims_populated_from_claim_verdicts():
-    col = _collector()
-    fc_result = FactCheckResult(
-        results=[
-            DataSourceResult(
-                data_source_id="ds-1",
-                source_type="original_text",
-                claim_verdicts=[
-                    ClaimVerdict(claim_id="c-1", claim_text="Claim A", verdict="Falso", justification="J1", citations_used=[]),
-                    ClaimVerdict(claim_id="c-2", claim_text="Claim B", verdict="Verdadeiro", justification="J2", citations_used=[]),
-                ],
-            )
-        ],
-        overall_summary="Summary.",
-    )
-
-    col.populate_from_graph_output(
-        fact_check_result=fc_result,
-        fact_check_results=[],
-        search_results={},
-        scraped_pages=[],
-    )
-
-    assert "1" in col.analytics.Claims
-    assert "2" in col.analytics.Claims
-    assert col.analytics.Claims["1"].text == "Claim A"
-    assert col.analytics.Claims["2"].text == "Claim B"
-
-
 def test_empty_source_lists():
     col = _collector()
     fc_result = _make_fact_check_result(justification="No sources.")
@@ -344,9 +315,11 @@ def test_has_extracted_claims_false_with_empty_claim_verdicts():
     assert col.has_extracted_claims() is False
 
 
-def test_has_extracted_claims_true_with_claims_dict_only():
-    """manually adding a claim via Claims dict should be enough."""
+def test_has_extracted_claims_true_with_response_by_claim():
+    """ResponseByClaim with entries should be enough."""
     col = _collector()
-    from app.models.analytics import ClaimAnalytics
-    col.analytics.Claims["1"] = ClaimAnalytics(text="manual claim", links=[])
+    from app.models.analytics import ClaimResponseAnalytics
+    col.analytics.ResponseByClaim["1"] = ClaimResponseAnalytics(
+        claim_id="c-1", claim_text="claim", Result="Falso", reasoningText="reason"
+    )
     assert col.has_extracted_claims() is True


### PR DESCRIPTION
has_extracted_claims now checks for actual claim_verdicts inside ResponseByDataSource instead of just checking list length, which was returning True for entries with zero claims.